### PR TITLE
Add support for cleaning up build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+ninja/
+log/
+install/
+build/

--- a/buildenv
+++ b/buildenv
@@ -1,0 +1,44 @@
+export ZOPEN_GIT_URL="git@github.com:ninja-build/ninja.git"
+export ZOPEN_TYPE="GIT"
+export ZOPEN_DEPS="cmake git zoslib"
+export ZOPEN_GIT_DEPS=""
+
+export ZOPEN_CONFIGURE="cmake"
+export ZOPEN_CONFIGURE_OPTS=" -B ../build --install-prefix \$ZOPEN_INSTALL_DIR/ ."
+
+export ZOPEN_MAKE="cmake"
+export ZOPEN_MAKE_OPTS=" --build ../build --target all"
+export ZOPEN_MINIMAL=Y
+
+export ZOPEN_INSTALL="cmake"
+export ZOPEN_INSTALL_OPTS=" --install ../build "
+
+export ZOPEN_CHECK=../build/ninja_test
+
+export ZOPEN_CLEAN=ninja_clean
+
+ninja_clean()
+{
+ rm -rf ../build
+}
+
+zopen_check_results()
+{
+  dir="$1"
+  pfx="$2"
+  chk="$1/$2_check.log"
+  awk '
+/^\*\*\* Failure/ { f++}
+/^\[/ { c++ }
+END {
+  print "actualFailures:" f+0
+  print "totalTests:" c+0
+  print "expectedFailures:2"
+}
+' $chk
+}
+
+zopen_append_to_env()
+{
+  # echo envars outside of PATH, MANPATH, LIBPATH
+}


### PR DESCRIPTION
1. change the cmake steps so the build is done outside of the ninja directory (eg. ../build)
2. use cmake for the build & install steps
3. add the clean up function that deletes the ../build subdir.